### PR TITLE
Fix to warnings about deprecated use of 'class' keyword in protocol

### DIFF
--- a/Sources/UBottomSheet/Classes/UBottomSheetCoordinatorDataSource.swift
+++ b/Sources/UBottomSheet/Classes/UBottomSheetCoordinatorDataSource.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 ///Data source
-public protocol UBottomSheetCoordinatorDataSource: class {
+public protocol UBottomSheetCoordinatorDataSource: AnyObject {
     ///Gesture end animation
     var animator: Animatable? { get }
     ///Sheet positions. For example top, middle, bottom y values.

--- a/Sources/UBottomSheet/Classes/UBottomSheetCoordinatorDelegate.swift
+++ b/Sources/UBottomSheet/Classes/UBottomSheetCoordinatorDelegate.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 ///Sheet delegate
-public protocol UBottomSheetCoordinatorDelegate: class {
+public protocol UBottomSheetCoordinatorDelegate: AnyObject {
     func bottomSheet(_ container: UIView?, finishTranslateWith extraAnimation: @escaping ((_ percent: CGFloat) -> Void) -> Void)
     func bottomSheet(_ container: UIView?, didChange state: SheetTranslationState)
     func bottomSheet(_ container: UIView?, didPresent state: SheetTranslationState)


### PR DESCRIPTION
Fixes #72 Small update to fix xcode 12.5 warning "using class keyword for protocol inheritance is deprecated use AnyObject instead".